### PR TITLE
update documentation to show new syntax for creating ollama models with client.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,8 +414,9 @@ API Documentation: https://github.com/jmorganca/ollama/blob/main/docs/api.md#cre
 
 ```ruby
 result = client.create(
-  { name: 'mario',
-    modelfile: "FROM llama2\nSYSTEM You are mario from Super Mario Bros." }
+  { model: 'mario',
+    from: 'llama3.2',
+    system: 'You are mario from Super Mario Bros.' }
 ) do |event, raw|
   puts event
 end


### PR DESCRIPTION
I ran into an issue when I recently updated Ollama and I figured it was an API change. #6 
They changed the way that you send parameters for creating models with Ollama and simplified it.
Previously you would need to pass in a complex modelfile string into the client.create 
```
result = client.create(
  { name: 'mario',
    modelfile: "FROM llama2\nSYSTEM You are mario from Super Mario Bros." }
) do |event, raw|
  puts event
end 
```

Now this is simplified by setting the model, from, and system parameter separately as keys like this
```
result = client.create(
  { model: 'mario',
    from: 'llama3.2',
    system: 'You are mario from Super Mario Bros.' }
) do |event, raw|
  puts event
end
```

I updated the docs to show the new syntax of creating ollama models with `client.create` so hopefully this helps other developers who are using this gem.